### PR TITLE
Bigarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for OCaml `Bigarray.Array1` values (PR #26 by @g2p)
+
 ## [0.8.8] - 2022-03-23
 
 ### Fixed

--- a/src/compile_fail_tests.rs
+++ b/src/compile_fail_tests.rs
@@ -27,3 +27,19 @@ pub struct LivenessFailureCheck;
 /// }
 /// ```
 pub struct NoStaticDerefsForNonImmediates;
+
+// Must fail with:
+// error[E0502]: cannot borrow `*cr` as mutable because it is also borrowed as immutable
+/// ```compile_fail
+/// # use ocaml_interop::*;
+/// # use ocaml_interop::bigarray::Array1;
+/// # use std::borrow::Borrow;
+/// # ocaml! { pub fn ocaml_function(arg1: Array1<u8>); }
+/// # let cr = &mut OCamlRuntime::init();
+/// let arr: Vec<u8> = (0..16).collect();
+/// let oarr: OCaml<Array1<u8>> = arr.as_slice().to_ocaml(cr);
+/// let slice: &[u8] = oarr.borrow();
+/// let result = ocaml_function(cr, &oarr);
+/// println!("{:?}", slice);
+/// # ()
+pub struct BigarraySliceEscapeCheck;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,7 @@ pub use crate::error::OCamlException;
 pub use crate::memory::alloc_cons as cons;
 pub use crate::memory::OCamlRef;
 pub use crate::mlvalues::{
-    DynBox, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml,
+    bigarray, DynBox, OCamlBytes, OCamlFloat, OCamlInt, OCamlInt32, OCamlInt64, OCamlList, RawOCaml,
 };
 pub use crate::runtime::OCamlRuntime;
 pub use crate::value::OCaml;

--- a/src/mlvalues.rs
+++ b/src/mlvalues.rs
@@ -12,6 +12,7 @@ pub use ocaml_sys::{
 };
 
 pub mod tag;
+pub mod bigarray;
 
 /// [`OCaml`]`<OCamlList<T>>` is a reference to an OCaml `list` containing
 /// values of type `T`.

--- a/src/mlvalues/bigarray.rs
+++ b/src/mlvalues/bigarray.rs
@@ -1,0 +1,48 @@
+use core::marker::PhantomData;
+
+/// Bigarray kind
+///
+/// # Safety
+///
+/// This is unsafe to implement, because it allows casts
+/// to the implementing type (through OCaml<Array1<T>>::as_slice()).
+///
+/// To make this safe, the type implementing this trait must be
+/// safe to transmute from OCaml data with the relevant KIND.
+//
+// Using a trait for this means a Rust type can only be matched to a
+// single kind.  There are enough Rust types that this isn't a problem
+// in practice.
+pub unsafe trait BigarrayElt: Copy {
+    /// OCaml bigarray type identifier
+    const KIND: i32;
+}
+
+// TODO:
+// assert that size_of::<$t>() matches caml_ba_element_size[$k]
+// Not sure we can check this at compile time,
+// when caml_ba_element_size is a C symbol
+macro_rules! make_kind {
+    ($t:ty, $k:ident) => {
+        unsafe impl BigarrayElt for $t {
+            const KIND: i32 = ocaml_sys::bigarray::Kind::$k as i32;
+        }
+    };
+}
+
+// In kind order
+// Skips some kinds OCaml supports: caml_int, complex32, complex64
+make_kind!(f32, FLOAT32);
+make_kind!(f64, FLOAT64);
+make_kind!(i8, SINT8);
+make_kind!(u8, UINT8);
+make_kind!(i16, SINT16);
+make_kind!(u16, UINT16);
+make_kind!(i32, INT32);
+make_kind!(i64, INT64);
+make_kind!(isize, NATIVE_INT);
+make_kind!(char, CHAR);
+
+pub struct Array1<A: BigarrayElt> {
+    _marker: PhantomData<A>,
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -480,3 +480,24 @@ impl_tuple!(
     6: tuple_7 -> G,
     7: tuple_8 -> H,
     8: tuple_9 -> I);
+
+impl<'a, A: bigarray::BigarrayElt> OCaml<'a, bigarray::Array1<A>> {
+    /// Returns the number of items in `self`
+    pub fn len(&self) -> usize {
+        let ba = unsafe { self.custom_ptr_val::<ocaml_sys::bigarray::Bigarray>() };
+        unsafe { *((*ba).dim.as_ptr() as *const usize) }
+    }
+
+    /// Returns true when `self.len() == 0`
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get underlying data as Rust slice
+    pub fn as_slice(&self) -> &[A] {
+        unsafe {
+            let ba = self.custom_ptr_val::<ocaml_sys::bigarray::Bigarray>();
+            slice::from_raw_parts((*ba).data as *const A, self.len())
+        }
+    }
+}

--- a/testing/rust-caller/ocaml/callable.ml
+++ b/testing/rust-caller/ocaml/callable.ml
@@ -30,12 +30,12 @@ let increment_bytes bytes first_n =
   bytes
 
 let decrement_bytes bytes first_n =
-    let limit = (min (Bytes.length bytes) first_n) - 1 in
-    for i = 0 to limit do
-      let value = (Bytes.get_uint8 bytes i) - 1 in
-      Bytes.set_uint8 bytes i value
-    done;
-    bytes
+  let limit = (min (Bytes.length bytes) first_n) - 1 in
+  for i = 0 to limit do
+    let value = (Bytes.get_uint8 bytes i) - 1 in
+    Bytes.set_uint8 bytes i value
+  done;
+  bytes
 
 let increment_ints_list ints =
   List.map ((+) 1) ints
@@ -77,6 +77,14 @@ let reverse_list_and_compact l =
  Gc.compact ();
  r
 
+let double_u16_array arr =
+  let open Bigarray in
+  let n = Array1.dim arr in
+  for i = 0 to pred n do
+    Array1.(set arr i ((get arr i) * 2))
+  done
+
+
 let () =
   Callback.register "increment_bytes" increment_bytes;
   Callback.register "decrement_bytes" decrement_bytes;
@@ -94,3 +102,4 @@ let () =
   Callback.register "raises_nonblock_exception" raises_nonblock_exception;
   Callback.register "gc_compact" Gc.compact;
   Callback.register "reverse_list_and_compact" reverse_list_and_compact;
+  Callback.register "double_u16_array" double_u16_array;


### PR DESCRIPTION
This exposes Bigarray.Array1 to Rust, with a Borrow implementation that allows read-only access to Bigarrays without copies.

(Marking as draft for cosmetic reasons: I'd like to flatten the module structure, and there will be fewer conflicts if I can do that after other PRs are merged)