### PR TITLE
Remove need for calling`ocaml_interop_setup` from OCaml programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom_ptr_val` method to `OCaml<T>` to obtain pointers to values embedded in OCaml custom blocks (by @g2p). Experimental API.
 - `DynBox<T>`, support for custom OCaml values that wrap Rust values (by @g2p). Experimental API.
 
+### Changed
+
+- There is no longer a need to `ocaml_interop_setup` from OCaml programs.
+
 ## [0.8.0] - 2021-04-07
 
 ### Added

--- a/src/boxroot.rs
+++ b/src/boxroot.rs
@@ -1,10 +1,10 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{marker::PhantomData, ops::Deref};
+use std::{marker::PhantomData, ops::Deref, sync::Once};
 
 use ocaml_boxroot_sys::{
-    boxroot_create, boxroot_delete, boxroot_get, boxroot_get_ref, boxroot_modify,
+    boxroot_create, boxroot_delete, boxroot_get, boxroot_get_ref, boxroot_modify, boxroot_setup,
     BoxRoot as PrimitiveBoxRoot,
 };
 
@@ -19,6 +19,12 @@ pub struct BoxRoot<T: 'static> {
 impl<T> BoxRoot<T> {
     /// Creates a new root from an [`OCaml`]`<T>` value.
     pub fn new(val: OCaml<T>) -> BoxRoot<T> {
+        static INIT: Once = Once::new();
+
+        INIT.call_once(|| unsafe {
+            boxroot_setup();
+        });
+
         BoxRoot {
             boxroot: unsafe { boxroot_create(val.raw) },
             _marker: PhantomData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,6 @@
 //! To be able to call these from Rust, there are a few things that need to be done:
 //!
 //! - Rust-driven programs must initialize the OCaml runtime.
-//! - OCaml-driven programs must call the `ocaml_interop_setup` function.
 //! - Functions that were exported from the OCaml side with `Callback.register` have to be declared using the [`ocaml!`] macro.
 //!
 //! ### Example
@@ -227,8 +226,6 @@
 //! ### Calling into Rust from OCaml
 //!
 //! To be able to call a Rust function from OCaml, it has to be defined in a way that exposes it to OCaml. This can be done with the [`ocaml_export!`] macro.
-//!
-//! If the program is OCaml-driven, the `ocaml_interop_setup` function must be called from OCaml first, and the `ocaml_interop_teardown` function must be called at the end of the OCaml program.
 //!
 //! #### Example
 //!

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -37,7 +37,6 @@ impl OCamlRuntime {
             let c_args = vec![arg0, core::ptr::null()];
             unsafe {
                 caml_startup(c_args.as_ptr());
-                boxroot_setup();
             }
         })
     }

--- a/testing/ocaml-caller/ocaml_rust_caller.ml
+++ b/testing/ocaml-caller/ocaml_rust_caller.ml
@@ -20,9 +20,6 @@ type movement_polymorphic =
   | `UnkownBlock of int ]
 
 module Rust = struct
-  (* Must be called first *)
-  external tests_setup : unit -> unit = "ocaml_interop_setup"
-
   external tests_teardown : unit -> unit = "ocaml_interop_teardown"
 
   external twice : int -> int = "rust_twice"
@@ -175,7 +172,6 @@ let test_regular_section () =
   Alcotest.check testable "Acquires the runtime lock" () ()
 
 let () =
-  Rust.tests_setup ();
   let open Alcotest in
   run "Tests"
     [


### PR DESCRIPTION
Now boxroots are setup implicitly when needed.