### PR TITLE
use ocaml_sys::Char instead of i8

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -123,7 +123,7 @@ pub fn alloc_cons<'a, 'b, A>(
 }
 
 const BOX_OPS_DYN_DROP: custom_operations = custom_operations {
-    identifier: "_rust_box_dyn_drop\0".as_ptr() as *const i8,
+    identifier: "_rust_box_dyn_drop\0".as_ptr() as *const ocaml_sys::Char,
     finalize: Some(drop_box_dyn),
     compare: None,
     hash: None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -33,7 +33,7 @@ impl OCamlRuntime {
         static INIT: Once = Once::new();
 
         INIT.call_once(|| {
-            let arg0 = "ocaml\0".as_ptr() as *const i8;
+            let arg0 = "ocaml\0".as_ptr() as *const ocaml_sys::Char;
             let c_args = vec![arg0, core::ptr::null()];
             unsafe {
                 caml_startup(c_args.as_ptr());


### PR DESCRIPTION
Currently ocaml-interop doesn’t build on arm64 because `char` is defined as `u8` there, you can use `ocaml_sys::Char` in place of `i8` to avoid this.