### PR TITLE
Add `no-caml-startup` feature flag that avoids the `caml_startup` symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `no-caml-startup` feature flag that disables calls to `caml_startup` when initializing the runtime. This makes `OCamlRuntime::init_persistent()` a noop. It is useful for being able to load code that uses `ocaml-rs` in an utop toplevel (for example, when running `dune utop`). Will be enabled if the environment variable `OCAML_INTEROP_NO_CAML_STARTUP` is set. This is a temporary option that is likely to be removed in the future once a better solution is implemented.
+
 ## [0.8.4] - 2021-05-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ static_assertions = "1.1.0"
 [features]
 without-ocamlopt = ["ocaml-sys/without-ocamlopt", "ocaml-boxroot-sys/without-ocamlopt"]
 caml-state = ["ocaml-sys/caml-state"]
+no-caml-startup = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Viable Systems and TezEdge Contributors
+// SPDX-License-Identifier: MIT
+
+const OCAML_INTEROP_NO_CAML_STARTUP: &str = "OCAML_INTEROP_NO_CAML_STARTUP";
+
+fn main() {
+    println!(
+        "cargo:rerun-if-env-changed={}",
+        OCAML_INTEROP_NO_CAML_STARTUP
+    );
+    if std::env::var(OCAML_INTEROP_NO_CAML_STARTUP).is_ok() {
+        println!("cargo:rustc-cfg=feature=\"no-caml-startup\"");
+    }
+}

--- a/testing/ocaml-caller/rust/Cargo.toml
+++ b/testing/ocaml-caller/rust/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 ocaml-interop = { path = "../../../../.." }
-# Above is for building with dune, bellow is for biulding from this directory
+# Above is for building with dune, bellow is for building from this directory
 # ocaml-interop = { path = "../../.." }


### PR DESCRIPTION
This will make `OCamlRuntime::init_persistent()` a noop.

The main motivation for this feature flag is to make code that uses
ocaml-rs and ocaml-interop loadable from `dune utop`:

https://github.com/zshipko/ocaml-rs/issues/70