### PR TITLE
Add `OCamlFromRust` and `OCamlToRust` traits

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 mod from_ocaml;
+mod ocaml_from_rust;
+mod ocaml_to_rust;
 mod to_ocaml;
 
 pub use self::from_ocaml::FromOCaml;
+pub use self::ocaml_from_rust::OCamlFromRust;
+pub use self::ocaml_to_rust::OCamlToRust;
 pub use self::to_ocaml::ToOCaml;

--- a/src/conv/ocaml_from_rust.rs
+++ b/src/conv/ocaml_from_rust.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Viable Systems and TezEdge Contributors
+// SPDX-License-Identifier: MIT
+
+use crate::{BoxRoot, OCaml, OCamlRuntime};
+
+use super::ToOCaml;
+
+/// Implements conversion from Rust values into OCaml values.
+///
+/// This trait enables the definition of conversions for types
+/// that have been defined in other crates.
+///
+/// It contains a default implementation for types that implement [`ToOCaml`].
+pub unsafe trait OCamlFromRust<'gc, RustT>
+where
+    Self: Sized,
+{
+    /// Convert from Rust value.
+    fn ocaml_from_rust(cr: &'gc mut OCamlRuntime, v: &RustT) -> OCaml<'gc, Self>;
+
+    /// Convert from Rust value. Return an already rooted value as [`BoxRoot`]`<Self>`.
+    fn boxroot_from_rust(cr: &'gc mut OCamlRuntime, v: &RustT) -> BoxRoot<Self> {
+        BoxRoot::new(Self::ocaml_from_rust(cr, v))
+    }
+}
+
+unsafe impl<'gc, RustT, OCamlT> OCamlFromRust<'gc, RustT> for OCamlT
+where
+    RustT: ToOCaml<OCamlT>,
+{
+    fn ocaml_from_rust(cr: &'gc mut OCamlRuntime, v: &RustT) -> OCaml<'gc, OCamlT> {
+        v.to_ocaml(cr)
+    }
+}

--- a/src/conv/ocaml_from_rust.rs
+++ b/src/conv/ocaml_from_rust.rs
@@ -11,24 +11,24 @@ use super::ToOCaml;
 /// that have been defined in other crates.
 ///
 /// It contains a default implementation for types that implement [`ToOCaml`].
-pub unsafe trait OCamlFromRust<'gc, RustT>
+pub unsafe trait OCamlFromRust<RustT>
 where
     Self: Sized,
 {
     /// Convert from Rust value.
-    fn ocaml_from_rust(cr: &'gc mut OCamlRuntime, v: &RustT) -> OCaml<'gc, Self>;
+    fn ocaml_from_rust<'gc>(cr: &'gc mut OCamlRuntime, v: &RustT) -> OCaml<'gc, Self>;
 
     /// Convert from Rust value. Return an already rooted value as [`BoxRoot`]`<Self>`.
-    fn boxroot_from_rust(cr: &'gc mut OCamlRuntime, v: &RustT) -> BoxRoot<Self> {
+    fn boxroot_from_rust<'gc>(cr: &'gc mut OCamlRuntime, v: &RustT) -> BoxRoot<Self> {
         BoxRoot::new(Self::ocaml_from_rust(cr, v))
     }
 }
 
-unsafe impl<'gc, RustT, OCamlT> OCamlFromRust<'gc, RustT> for OCamlT
+unsafe impl<RustT, OCamlT> OCamlFromRust<RustT> for OCamlT
 where
     RustT: ToOCaml<OCamlT>,
 {
-    fn ocaml_from_rust(cr: &'gc mut OCamlRuntime, v: &RustT) -> OCaml<'gc, OCamlT> {
+    fn ocaml_from_rust<'gc>(cr: &'gc mut OCamlRuntime, v: &RustT) -> OCaml<'gc, OCamlT> {
         v.to_ocaml(cr)
     }
 }

--- a/src/conv/ocaml_to_rust.rs
+++ b/src/conv/ocaml_to_rust.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Viable Systems and TezEdge Contributors
+// SPDX-License-Identifier: MIT
+
+use crate::OCaml;
+
+use super::FromOCaml;
+
+/// Implements conversion from OCaml values into Rust values.
+///
+/// This trait enables the definition of conversions for types
+/// that have been defined in other crates.
+///
+/// It contains a default implementation for types that implement [`FromOCaml`].
+pub unsafe trait OCamlToRust<RustT>
+where
+    Self: Sized,
+{
+    /// Convert to Rust value.
+    fn ocaml_to_rust(v: OCaml<Self>) -> RustT;
+}
+
+unsafe impl<RustT, OCamlT> OCamlToRust<RustT> for OCamlT
+where
+    RustT: FromOCaml<OCamlT>,
+{
+    fn ocaml_to_rust(v: OCaml<Self>) -> RustT {
+        RustT::from_ocaml(v)
+    }
+}

--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -197,7 +197,7 @@ macro_rules! tuple_to_ocaml {
     ($($n:tt: $t:ident => $ot:ident),+) => {
         unsafe impl<$($t),+, $($ot: 'static),+> ToOCaml<($($ot),+)> for ($($t),+)
         where
-            $($t: ToOCaml<$ot>),+
+            $($ot: $crate::OCamlFromRust<$t>),+
         {
             fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, ($($ot),+)> {
                 let len = $crate::count_fields!($($t)*);
@@ -205,7 +205,8 @@ macro_rules! tuple_to_ocaml {
                 unsafe {
                     let ocaml_tuple: BoxRoot<($($ot),+)> = BoxRoot::new(alloc_tuple(cr, len));
                     $(
-                        let field_val = self.$n.to_ocaml(cr).get_raw();
+                        let field_val: $crate::OCaml<$ot> = $crate::OCamlFromRust::ocaml_from_rust(cr, &self.$n);
+                        let field_val = field_val.get_raw();
                         store_field(ocaml_tuple.get(cr).raw(), $n, field_val);
                     )+
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ mod value;
 pub use crate::boxroot::BoxRoot;
 
 pub use crate::closure::{OCamlFn1, OCamlFn2, OCamlFn3, OCamlFn4, OCamlFn5};
-pub use crate::conv::{FromOCaml, ToOCaml};
+pub use crate::conv::{FromOCaml, OCamlFromRust, OCamlToRust, ToOCaml};
 pub use crate::error::OCamlException;
 pub use crate::memory::alloc_cons as cons;
 pub use crate::memory::OCamlRef;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -690,7 +690,7 @@ macro_rules! impl_ocaml_from_rust {
     ($rust_typ:ty => $ocaml_typ:ident {
         $($field:ident : $ocaml_field_typ:ty $(=> $conv_expr:expr)?),+ $(,)?
     }) => {
-        unsafe impl $crate::OCamlFromRust<'_, $rust_typ> for $ocaml_typ {
+        unsafe impl $crate::OCamlFromRust<$rust_typ> for $ocaml_typ {
             fn ocaml_from_rust<'a>(cr: &'a mut $crate::OCamlRuntime, r: &$rust_typ) -> $crate::OCaml<'a, $ocaml_typ> {
                 $crate::ocaml_alloc_record! {
                     cr, r {
@@ -717,7 +717,7 @@ macro_rules! impl_ocaml_from_rust {
     ($rust_typ:ty => $ocaml_typ:ty {
         $($t:tt)*
     }) => {
-        unsafe impl $crate::OCamlFromRust<'_, $rust_typ> for $ocaml_typ {
+        unsafe impl $crate::OCamlFromRust<$rust_typ> for $ocaml_typ {
             fn ocaml_from_rust<'a>(cr: &'a mut $crate::OCamlRuntime, r: &$rust_typ) -> $crate::OCaml<'a, $ocaml_typ> {
                 $crate::ocaml_alloc_variant! {
                     cr, r => {
@@ -732,7 +732,7 @@ macro_rules! impl_ocaml_from_rust {
     (@polymorphic $rust_typ:ty => $ocaml_typ:ty {
         $($t:tt)*
     }) => {
-        unsafe impl $crate::OCamlFromRust<'_, $rust_typ> for $ocaml_typ {
+        unsafe impl $crate::OCamlFromRust<$rust_typ> for $ocaml_typ {
             fn ocaml_from_rust<'a>(cr: &'a mut $crate::OCamlRuntime, r: &$rust_typ) -> $crate::OCaml<'a, $ocaml_typ> {
                 $crate::ocaml_alloc_polymorphic_variant! {
                     cr, r => {

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,10 +3,11 @@
 
 use crate::{
     boxroot::BoxRoot,
+    conv::OCamlToRust,
     error::OCamlFixnumConversionError,
     memory::{alloc_box, OCamlCell},
     mlvalues::*,
-    FromOCaml, OCamlRef, OCamlRuntime,
+    OCamlRef, OCamlRuntime,
 };
 use core::any::Any;
 use core::borrow::Borrow;
@@ -115,9 +116,9 @@ impl<'a, T> OCaml<'a, T> {
     /// Converts this OCaml value into a Rust value.
     pub fn to_rust<RustT>(&self) -> RustT
     where
-        RustT: FromOCaml<T>,
+        T: OCamlToRust<RustT>,
     {
-        RustT::from_ocaml(*self)
+        T::ocaml_to_rust(*self)
     }
 
     /// Meant to match Data_custom_val from mlvalues.h


### PR DESCRIPTION
These traits enable the possibility to define conversions for types that have been defined in other crates.