### PR TITLE
fix type error

### DIFF
--- a/src/conv/to_ocaml.rs
+++ b/src/conv/to_ocaml.rs
@@ -48,7 +48,7 @@ unsafe impl ToOCaml<()> for () {
 
 unsafe impl ToOCaml<OCamlInt> for i64 {
     fn to_ocaml<'a>(&self, cr: &'a mut OCamlRuntime) -> OCaml<'a, OCamlInt> {
-        unsafe { OCaml::new(cr, ((self << 1) | 1) as RawOCaml) }
+        unsafe { OCaml::new(cr, ((self << 1) | 1i64) as RawOCaml) }
     }
 }
 


### PR DESCRIPTION
It's hard to reproduce, but I get this error in docker with debian 10, ocaml 4.12 + flambda:

```
Step #11 - "docker-build--base-build": # error[E0277]: no implementation for `i64 | i32`
Step #11 - "docker-build--base-build": #   --> /home/opam/.opam/4.12/.opam-switch/build/batsat.0.7/vendor/ocaml-interop/src/conv/to_ocaml.rs:51:46
Step #11 - "docker-build--base-build": #    |
Step #11 - "docker-build--base-build": # 51 |         unsafe { OCaml::new(cr, ((self << 1) | 1) as RawOCaml) }
Step #11 - "docker-build--base-build": #    |                                              ^ no implementation for `i64 | i32`
Step #11 - "docker-build--base-build": #    |
Step #11 - "docker-build--base-build": #    = help: the trait `std::ops::BitOr<i32>` is not implemented for `i64`
Step #11 - "docker-build--base-build": # 
Step #11 - "docker-build--base-build": # error: aborting due to previous error
```

of course it doesn't fail outside of it. I'm having trouble checking that this patch fixes it in the failing environment because opam + cargo-vendor is a pure nightmare, but this is still worth discussing?